### PR TITLE
Update doc links README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,7 @@ algorithms. Its flexibility and extensibility make it applicable to a
 large suite of problems.
 
 Check out the `PyMC overview <https://docs.pymc.io/en/latest/learn/examples/pymc_overview.html>`__,  or
-`interact with live examples <https://mybinder.org/v2/gh/pymc-devs/pymc/main?filepath=%2Fdocs%2Fsource%2Fnotebooks>`__
-using Binder!
+one of `the many examples <https://docs.pymc.io/projects/examples/en/latest/>`__!
 For questions on PyMC, head on over to our `PyMC Discourse <https://discourse.pymc.io/>`__ forum.
 
 Features


### PR DESCRIPTION
Fixes #5728, update links to overview and examples in the README.
